### PR TITLE
Fix for compilation error in entity.cpp

### DIFF
--- a/code/map.cpp
+++ b/code/map.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <cmath>
 #include <filesystem>
+#include <algorithm>
 
 #define STBI_NO_PSD
 #define STBI_NO_TGA

--- a/code/map.h
+++ b/code/map.h
@@ -8,7 +8,6 @@ const unsigned int MAX_TEXTURE_LENGTH = 16;
 #include <vector>
 #include <unordered_map>
 #include <cstdint>
-#include <algorithm>
 
 #include "math.h"
 #include "entity.h"

--- a/code/map.h
+++ b/code/map.h
@@ -8,6 +8,7 @@ const unsigned int MAX_TEXTURE_LENGTH = 16;
 #include <vector>
 #include <unordered_map>
 #include <cstdint>
+#include <algorithm>
 
 #include "math.h"
 #include "entity.h"


### PR DESCRIPTION
Got following error compiling on a Linux machine. Earlier versions compiled fine.

```cmake
/home/bernard/code/map-to-gltf/code/entity.cpp: In function ‘void RecalculateRHPrimitives(std::vector<Primitive>&)’:
/home/bernard/code/map-to-gltf/code/entity.cpp:131:14: error: ‘reverse’ is not a member of ‘std’
  131 |         std::reverse(primitive.indexBuffer.begin(), primitive.indexBuffer.end());
      |              ^~~~~~~
make[2]: *** [CMakeFiles/mtg.dir/build.make:118: CMakeFiles/mtg.dir/code/entity.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/mtg.dir/all] Error 2
make: *** [Makefile:91: all] Error 2

``` 

I can mention that I am novice in programming and never touched C++. I noticed that std::reverse is defined in algorithm library and included it in map.h. It compiles fine now!  This is my first pull request ever btw!

Tack för ett bra verktyg! :) 